### PR TITLE
Add missing OWNERS for r-o-e/release jobs

### DIFF
--- a/ci-operator/jobs/redhat-operator-ecosystem/release/OWNERS
+++ b/ci-operator/jobs/redhat-operator-ecosystem/release/OWNERS
@@ -4,3 +4,4 @@ approvers:
   - dirgim
   - jupierce
   - stevekuznetsov
+  - petr-muller


### PR DESCRIPTION
Once we fix the ci/prow/owners to do its job it will start complaining about this dir not having `OWNERS` file.

/cc @stevekuznetsov @jupierce 