### PR TITLE
 Use symlinks to work around rehearse limitations 

### DIFF
--- a/ci-operator/jobs/redhat-operator-ecosystem/release/redhat-operator-ecosystem-release-master-presubmits.yaml
+++ b/ci-operator/jobs/redhat-operator-ecosystem/release/redhat-operator-ecosystem-release-master-presubmits.yaml
@@ -158,7 +158,7 @@ presubmits:
         - --metrics-output=$(ARTIFACTS)/rehearse-metrics.json
         - --rehearsal-limit=35
         command:
-        - /bin/pj-rehearse
+        - ./hack/rehearse.sh
         image: pj-rehearse:latest
         imagePullPolicy: Always
         name: ""

--- a/ci-operator/jobs/redhat-operator-ecosystem/release/redhat-operator-ecosystem-release-master-presubmits.yaml
+++ b/ci-operator/jobs/redhat-operator-ecosystem/release/redhat-operator-ecosystem-release-master-presubmits.yaml
@@ -144,6 +144,10 @@ presubmits:
     - master
     context: ci/prow/pj-rehearse
     decorate: true
+    extra_refs:
+    - base_ref: master
+      org: openshift
+      repo: release
     name: pull-ci-redhat-operator-ecosystem-release-master-pj-rehearse
     optional: true
     rerun_command: /test pj-rehearse

--- a/ci-operator/jobs/redhat-operator-ecosystem/release/redhat-operator-ecosystem-release-master-presubmits.yaml
+++ b/ci-operator/jobs/redhat-operator-ecosystem/release/redhat-operator-ecosystem-release-master-presubmits.yaml
@@ -157,6 +157,9 @@ presubmits:
         - --dry-run=false
         - --metrics-output=$(ARTIFACTS)/rehearse-metrics.json
         - --rehearsal-limit=35
+        - --no-cluster-profiles
+        - --no-templates
+        - --no-registry
         command:
         - ./hack/rehearse.sh
         image: pj-rehearse:latest

--- a/hack/rehearse.sh
+++ b/hack/rehearse.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# pj-rehearse assumes all necessary config is present in the repository, but
+# redhat-operator-ecosystem/release only contains job configuration, not Prow
+# configuration (Prow config is in openshift/release). Work around this
+# limitation by symlinking the openshift/release config. This script assumes:
+#
+# 1) To be called from r-o-e/release working copy root as CWD
+# 2) With openshift/release checked out at ../../openshift/release from CWD
+
+prow_config_dir="core-services/prow/02_config"
+
+if [[ -e "${prow_config_dir}" ]]; then
+  echo "ERROR: ${prow_config_dir} already exists in the repo (pj-rehearse should be called directly)"
+  exit 1
+fi
+
+mkdir -p "$(dirname "${prow_config_dir}")"
+
+trap 'rm -rf $prow_config_dir' EXIT
+ln -s "$(pwd)/../../openshift/release/${prow_config_dir}" "${prow_config_dir}"
+
+pj-rehearse "$@"


### PR DESCRIPTION
pj-rehearse assumes all necessary config is present in the repository, but redhat-operator-ecosystem/release only contains job configuration, not Prow configuration (Prow config is in openshift/release). Work around this limitation by symlinking the openshift/release config.

/cc @stevekuznetsov 