### PR TITLE
Add ci-op configs for roe/playground for CVP jobs

### DIFF
--- a/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.5.yaml
+++ b/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.5.yaml
@@ -1,0 +1,22 @@
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: "4.5"
+  namespace: ocp
+tests:
+- as: cvp-common-aws
+  cron: "@yearly"
+  steps:
+    cluster_profile: aws
+    workflow: ipi
+- as: cvp-common-gcp
+  cron: "@yearly"
+  steps:
+    cluster_profile: gcp
+    workflow: ipi

--- a/ci-operator/jobs/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.5-periodics.yaml
+++ b/ci-operator/jobs/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.5-periodics.yaml
@@ -1,0 +1,159 @@
+periodics:
+- agent: kubernetes
+  cron: '@yearly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: cvp-ocp-4.5
+    org: redhat-operator-ecosystem
+    repo: playground
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-operator-ecosystem-playground-cvp-ocp-4.5-cvp-common-aws
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --branch=cvp-ocp-4.5
+      - --give-pr-author-access-to-namespace=true
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --lease-server=https://boskos-ci.svc.ci.openshift.org
+      - --org=redhat-operator-ecosystem
+      - --repo=playground
+      - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
+      - --secret-dir=/usr/local/cvp-common-aws-cluster-profile
+      - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+      - --target=cvp-common-aws
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/cvp-common-aws-cluster-profile
+        name: cluster-profile
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/sentry-dsn
+        name: sentry-dsn
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws
+    - name: pull-secret
+      secret:
+        secretName: regcred
+    - name: sentry-dsn
+      secret:
+        secretName: sentry-dsn
+- agent: kubernetes
+  cron: '@yearly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: cvp-ocp-4.5
+    org: redhat-operator-ecosystem
+    repo: playground
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-operator-ecosystem-playground-cvp-ocp-4.5-cvp-common-gcp
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --branch=cvp-ocp-4.5
+      - --give-pr-author-access-to-namespace=true
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --lease-server=https://boskos-ci.svc.ci.openshift.org
+      - --org=redhat-operator-ecosystem
+      - --repo=playground
+      - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
+      - --secret-dir=/usr/local/cvp-common-gcp-cluster-profile
+      - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+      - --target=cvp-common-gcp
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/cvp-common-gcp-cluster-profile
+        name: cluster-profile
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/sentry-dsn
+        name: sentry-dsn
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-gcp
+        - configMap:
+            name: cluster-profile-gcp
+    - name: pull-secret
+      secret:
+        secretName: regcred
+    - name: sentry-dsn
+      secret:
+        secretName: sentry-dsn


### PR DESCRIPTION
These ci-operator configs are intended to be referred to by (right now
hand-crafted) jobs triggered by the CVP pipeline to validate optional
operators.

We need to include also the periodic jobs generated from the ci-operator
configs, but these jobs are currently not useful for anything.