### PR TITLE
ci-operator-config: run the determinizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL=/usr/bin/env bash -o errexit
 
 CONTAINER_ENGINE ?= docker
 
-.PHONY: jobs prow-config new-repo
+.PHONY: jobs prow-config ci-operator-config new-repo
 
 # these are useful for devs
 jobs:
@@ -10,6 +10,10 @@ jobs:
 	$(CONTAINER_ENGINE) run --rm -v "$(CURDIR):/go/src/github.com/openshift/release:z" -e GOPATH=/go registry.svc.ci.openshift.org/ci/ci-operator-prowgen:latest --from-release-repo --to-release-repo
 	$(CONTAINER_ENGINE) pull registry.svc.ci.openshift.org/ci/sanitize-prow-jobs:latest
 	$(CONTAINER_ENGINE) run --rm -v "$(CURDIR)/ci-operator/jobs:/ci-operator/jobs:z" -v "$(CURDIR)/core-services/sanitize-prow-jobs:/core-services/sanitize-prow-jobs:z" registry.svc.ci.openshift.org/ci/sanitize-prow-jobs:latest --prow-jobs-dir /ci-operator/jobs --config-path /core-services/sanitize-prow-jobs/_config.yaml
+
+ci-operator-config:
+	$(CONTAINER_ENGINE) pull registry.svc.ci.openshift.org/ci/determinize-ci-operator:latest
+	$(CONTAINER_ENGINE) run --rm -v "$(CURDIR)/ci-operator/config:/ci-operator/config:z" registry.svc.ci.openshift.org/ci/determinize-ci-operator:latest --config-dir /ci-operator/config --confirm
 
 prow-config:
 	docker pull registry.svc.ci.openshift.org/ci/determinize-prow-config:latest

--- a/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.4.yaml
+++ b/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.4.yaml
@@ -11,7 +11,11 @@ tag_specification:
   namespace: ocp
 tests:
 - as: cvp-common-aws
-  cron: "@yearly"
+  cron: '@yearly'
   steps:
     cluster_profile: aws
     workflow: optional-operators-cvp-common-aws
+zz_generated_metadata:
+  branch: cvp-ocp-4.4
+  org: redhat-operator-ecosystem
+  repo: playground

--- a/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.5.yaml
+++ b/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.5.yaml
@@ -11,7 +11,11 @@ tag_specification:
   namespace: ocp
 tests:
 - as: cvp-common-aws
-  cron: "@yearly"
+  cron: '@yearly'
   steps:
     cluster_profile: aws
     workflow: optional-operators-cvp-common-aws
+zz_generated_metadata:
+  branch: cvp-ocp-4.5
+  org: redhat-operator-ecosystem
+  repo: playground

--- a/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-master.yaml
+++ b/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-master.yaml
@@ -4,37 +4,29 @@ base_images:
     name: ubi
     namespace: ocp
     tag: "7"
-
+binary_build_commands: make build
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
     name: release
     namespace: openshift
     tag: golang-1.13
-
 images:
 - dockerfile_path: Dockerfile
   from: bin
   inputs:
-    bin:
-      as:
-        - builder
     base:
       as:
-        - runtime
+      - runtime
+      paths: null
+    bin:
+      as:
+      - builder
+      paths: null
   to: redhat-operator-ecosystem-playground
-
-binary_build_commands: make build
-
 promotion:
   namespace: ci
   tag: latest
-
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  namespace: ocp
-  name: "4.4"
-
 resources:
   '*':
     limits:
@@ -42,7 +34,10 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
-
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: "4.4"
+  namespace: ocp
 tests:
 - as: unit
   commands: make test-unit
@@ -57,7 +52,11 @@ tests:
   openshift_installer_src:
     cluster_profile: aws
 - as: e2e-periodic
-  cron: '@yearly'
   commands: make test-e2e
+  cron: '@yearly'
   openshift_installer_src:
     cluster_profile: aws
+zz_generated_metadata:
+  branch: master
+  org: redhat-operator-ecosystem
+  repo: playground

--- a/ci-operator/jobs/redhat-operator-ecosystem/release/redhat-operator-ecosystem-release-master-presubmits.yaml
+++ b/ci-operator/jobs/redhat-operator-ecosystem/release/redhat-operator-ecosystem-release-master-presubmits.yaml
@@ -30,6 +30,33 @@ presubmits:
     branches:
     - master
     cluster: api.ci
+    context: ci/prow/ci-operator-config-metadata
+    decorate: true
+    extra_refs:
+    - base_ref: master
+      org: openshift
+      repo: release
+    labels:
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-release-master-ci-operator-config-metadata
+    rerun_command: /test ci-operator-config-metadata
+    spec:
+      containers:
+      - args:
+        - ./
+        command:
+        - ./../../hack/validate-ci-operator-config.sh
+        image: determinize-ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    cluster: api.ci
     context: ci/prow/ci-operator-registry
     decorate: true
     extra_refs:
@@ -164,7 +191,6 @@ presubmits:
         - --debug-log
         - $(ARTIFACTS)/debug-log.txt
         - --dry-run=false
-        - --metrics-output=$(ARTIFACTS)/rehearse-metrics.json
         - --rehearsal-limit=35
         - --no-cluster-profiles
         - --no-templates


### PR DESCRIPTION
This adds a `make` target for devs to update the configuration, a validation script to ensure that the contents are up-to-date and a new PR job to require up-to-date config for merge. We also update the config to be valid.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>