### PR TITLE
ciop config validate: use correct path to script in o/r

### DIFF
--- a/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-master.yaml
+++ b/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-master.yaml
@@ -16,11 +16,9 @@ images:
     base:
       as:
       - runtime
-      paths: null
     bin:
       as:
       - builder
-      paths: null
   to: redhat-operator-ecosystem-playground
 promotion:
   namespace: ci

--- a/ci-operator/jobs/redhat-operator-ecosystem/release/redhat-operator-ecosystem-release-master-presubmits.yaml
+++ b/ci-operator/jobs/redhat-operator-ecosystem/release/redhat-operator-ecosystem-release-master-presubmits.yaml
@@ -45,7 +45,7 @@ presubmits:
       - args:
         - ./
         command:
-        - ./../../hack/validate-ci-operator-config.sh
+        - ./../../openshift/release/hack/validate-ci-operator-config.sh
         image: determinize-ci-operator:latest
         imagePullPolicy: Always
         name: ""


### PR DESCRIPTION
This probably never worked...

/cc @stevekuznetsov 