### PR TITLE
Modernize CVP ci-operator configs

### DIFF
--- a/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.4.yaml
+++ b/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.4.yaml
@@ -1,3 +1,8 @@
+releases:
+  latest:
+    release:
+      channel: stable
+      version: "4.4"
 resources:
   '*':
     limits:
@@ -5,9 +10,6 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
-tag_specification:
-  name: "4.4"
-  namespace: ocp
 tests:
 - as: cvp-common-aws
   cron: '@yearly'

--- a/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.5.yaml
+++ b/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.5.yaml
@@ -1,3 +1,8 @@
+releases:
+  latest:
+    release:
+      channel: stable
+      version: "4.5"
 resources:
   '*':
     limits:
@@ -5,9 +10,6 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
-tag_specification:
-  name: "4.5"
-  namespace: ocp
 tests:
 - as: cvp-common-aws
   cron: '@yearly'

--- a/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.6.yaml
+++ b/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.6.yaml
@@ -1,0 +1,22 @@
+releases:
+  latest:
+    release:
+      channel: stable
+      version: "4.6"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: cvp-common-aws
+  cron: '@yearly'
+  steps:
+    cluster_profile: aws
+    workflow: optional-operators-cvp-common-aws
+zz_generated_metadata:
+  branch: cvp-ocp-4.6
+  org: redhat-operator-ecosystem
+  repo: playground

--- a/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.7.yaml
+++ b/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.7.yaml
@@ -1,0 +1,25 @@
+releases:
+  latest:
+    candidate:
+      architecture: amd64
+      product: ocp
+      relative: 1
+      stream: nightly
+      version: "4.7"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: cvp-common-aws
+  cron: '@yearly'
+  steps:
+    cluster_profile: aws
+    workflow: optional-operators-cvp-common-aws
+zz_generated_metadata:
+  branch: cvp-ocp-4.7
+  org: redhat-operator-ecosystem
+  repo: playground

--- a/ci-operator/jobs/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.4-periodics.yaml
+++ b/ci-operator/jobs/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.4-periodics.yaml
@@ -20,6 +20,7 @@ periodics:
       - --lease-server-password-file=/etc/boskos/password
       - --report-password-file=/etc/report/password.txt
       - --report-username=ci
+      - --secret-dir=/secrets/ci-pull-credentials
       - --secret-dir=/usr/local/cvp-common-aws-cluster-profile
       - --target=cvp-common-aws
       command:
@@ -33,6 +34,9 @@ periodics:
       volumeMounts:
       - mountPath: /etc/boskos
         name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
         readOnly: true
       - mountPath: /usr/local/cvp-common-aws-cluster-profile
         name: cluster-profile
@@ -50,6 +54,9 @@ periodics:
         - key: password
           path: password
         secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
     - name: cluster-profile
       projected:
         sources:

--- a/ci-operator/jobs/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.5-periodics.yaml
+++ b/ci-operator/jobs/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.5-periodics.yaml
@@ -20,6 +20,7 @@ periodics:
       - --lease-server-password-file=/etc/boskos/password
       - --report-password-file=/etc/report/password.txt
       - --report-username=ci
+      - --secret-dir=/secrets/ci-pull-credentials
       - --secret-dir=/usr/local/cvp-common-aws-cluster-profile
       - --target=cvp-common-aws
       command:
@@ -33,6 +34,9 @@ periodics:
       volumeMounts:
       - mountPath: /etc/boskos
         name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
         readOnly: true
       - mountPath: /usr/local/cvp-common-aws-cluster-profile
         name: cluster-profile
@@ -50,6 +54,9 @@ periodics:
         - key: password
           path: password
         secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
     - name: cluster-profile
       projected:
         sources:

--- a/ci-operator/jobs/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.6-periodics.yaml
+++ b/ci-operator/jobs/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.6-periodics.yaml
@@ -1,0 +1,70 @@
+periodics:
+- agent: kubernetes
+  cluster: api.ci
+  cron: '@yearly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: cvp-ocp-4.6
+    org: redhat-operator-ecosystem
+    repo: playground
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-operator-ecosystem-playground-cvp-ocp-4.6-cvp-common-aws
+  spec:
+    containers:
+    - args:
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-password-file=/etc/boskos/password
+      - --report-password-file=/etc/report/password.txt
+      - --report-username=ci
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --secret-dir=/usr/local/cvp-common-aws-cluster-profile
+      - --target=cvp-common-aws
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /usr/local/cvp-common-aws-cluster-profile
+        name: cluster-profile
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.7-periodics.yaml
+++ b/ci-operator/jobs/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.7-periodics.yaml
@@ -1,0 +1,71 @@
+periodics:
+- agent: kubernetes
+  cluster: api.ci
+  cron: '@yearly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: cvp-ocp-4.7
+    org: redhat-operator-ecosystem
+    repo: playground
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    job-release: "4.7"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-redhat-operator-ecosystem-playground-cvp-ocp-4.7-cvp-common-aws
+  spec:
+    containers:
+    - args:
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-password-file=/etc/boskos/password
+      - --report-password-file=/etc/report/password.txt
+      - --report-username=ci
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --secret-dir=/usr/local/cvp-common-aws-cluster-profile
+      - --target=cvp-common-aws
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /usr/local/cvp-common-aws-cluster-profile
+        name: cluster-profile
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator


### PR DESCRIPTION
- Use customer-released payload for 4.4 (instead of previously used ephemeral release)
- Use customer-released payload for 4.5 (instead of previously used ephemeral release)
- Add config for testing operators on OCP 4.6 (use customer-released payload)
- Add config for testing operators on OCP 4.7 (use latest nightly for 4.7 for now, no version yet available for customers)

/cc @stevekuznetsov @dirgim

Resolves: [DPTP-1742](https://issues.redhat.com/browse/DPTP-1742)