### PR TITLE
[CVP-1615]Adding base images for operator scorecard tests

### DIFF
--- a/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.4.yaml
+++ b/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.4.yaml
@@ -20,3 +20,8 @@ zz_generated_metadata:
   branch: cvp-ocp-4.4
   org: redhat-operator-ecosystem
   repo: playground
+base_images:
+  cvp-operator-scorecard:
+    name: cvp-operator-scorecard
+    namespace: ci
+    tag: v1

--- a/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.5.yaml
+++ b/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.5.yaml
@@ -20,3 +20,8 @@ zz_generated_metadata:
   branch: cvp-ocp-4.5
   org: redhat-operator-ecosystem
   repo: playground
+base_images:
+  cvp-operator-scorecard:
+    name: cvp-operator-scorecard
+    namespace: ci
+    tag: v1

--- a/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.6.yaml
+++ b/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.6.yaml
@@ -20,3 +20,8 @@ zz_generated_metadata:
   branch: cvp-ocp-4.6
   org: redhat-operator-ecosystem
   repo: playground
+base_images:
+  cvp-operator-scorecard:
+    name: cvp-operator-scorecard
+    namespace: ci
+    tag: v1

--- a/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.7.yaml
+++ b/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-cvp-ocp-4.7.yaml
@@ -23,3 +23,8 @@ zz_generated_metadata:
   branch: cvp-ocp-4.7
   org: redhat-operator-ecosystem
   repo: playground
+base_images:
+  cvp-operator-scorecard:
+    name: cvp-operator-scorecard
+    namespace: ci
+    tag: v1

--- a/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-master.yaml
+++ b/ci-operator/config/redhat-operator-ecosystem/playground/redhat-operator-ecosystem-playground-master.yaml
@@ -3,6 +3,10 @@ base_images:
     name: ubi
     namespace: ocp
     tag: "8"
+  cvp-operator-scorecard:
+    name: cvp-operator-scorecard
+    namespace: ci
+    tag: v1
 binary_build_commands: make build
 build_root:
   image_stream_tag:


### PR DESCRIPTION
This PR can be merged after : https://github.com/openshift/release/pull/16475 is successfully merged.

The operator-sdk scorecard will need to be run on all operator bundle images that are tested with the Operator verification pipeline.
To this end, a new step implementing this will need to be added to the cvp-common workflow in the OpenShift-CI/DPTP Prow configuration.
Image that will be used for runing scorecard tests needs to be made available on the OpenShift-CI app.ci cluster and specified in the prow workflow step configuration (PR mentioned above). This base_images configuration changes needs to be specified for each OCP version of the job redhat-operator-ecosystem-playground.